### PR TITLE
feat: add JWT auth controller

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Tymon\JWTAuth\Facades\JWTAuth;
+
+class AuthController extends Controller
+{
+    public function login(Request $request)
+    {
+        $cred = $request->validate([
+            'email' => ['required', 'email'],
+            'password' => ['required'],
+        ]);
+
+        if (! $token = auth('api')->attempt($cred)) {
+            return response()->json(['message' => 'Invalid credentials'], 401);
+        }
+
+        $user = auth('api')->user();
+
+        return response()->json([
+            'token' => $token,
+            'user' => [
+                'id' => $user->id,
+                'name' => $user->name,
+                'email' => $user->email,
+            ],
+        ]);
+    }
+
+    public function me(Request $request)
+    {
+        $u = auth('api')->user();
+        return response()->json([
+            'id' => $u->id,
+            'name' => $u->name,
+            'email' => $u->email,
+        ]);
+    }
+
+    public function logout()
+    {
+        auth('api')->logout();
+        return response()->json(['ok' => true]);
+    }
+}

--- a/tests/Feature/AuthControllerTest.php
+++ b/tests/Feature/AuthControllerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AuthControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_login_returns_token_and_user(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->postJson('/api/auth/login', [
+            'email' => $user->email,
+            'password' => 'password',
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'token',
+                'user' => ['id', 'name', 'email'],
+            ]);
+
+        $data = $response->json();
+        $this->assertNotEmpty($data['token']);
+        $this->assertEquals($user->id, $data['user']['id']);
+        $this->assertEquals($user->name, $data['user']['name']);
+        $this->assertEquals($user->email, $data['user']['email']);
+    }
+
+    public function test_me_returns_user_info_with_valid_token(): void
+    {
+        $user = User::factory()->create();
+        $token = auth('api')->login($user);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->getJson('/api/auth/me');
+
+        $response->assertStatus(200)
+            ->assertExactJson([
+                'id' => $user->id,
+                'name' => $user->name,
+                'email' => $user->email,
+            ]);
+    }
+
+    public function test_logout_invalidates_token(): void
+    {
+        $user = User::factory()->create();
+        $token = auth('api')->login($user);
+
+        $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/auth/logout')
+            ->assertStatus(200)
+            ->assertExactJson(['ok' => true]);
+
+        $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->getJson('/api/auth/me')
+            ->assertStatus(401);
+    }
+}


### PR DESCRIPTION
## Summary
- add AuthController with JWT login, me, and logout endpoints
- add feature tests covering login, user retrieval, and token invalidation

## Testing
- `COMPOSER_NO_INTERACTION=1 composer install` (fails: unable to access github.com, CONNECT tunnel failed 403)
- `composer test` (fails: require vendor/autoload.php, file not found)


------
https://chatgpt.com/codex/tasks/task_e_68baa0927fc88330be0413fbb0e2fbfb