### PR TITLE
Add attendance controller and models

### DIFF
--- a/app/Http/Controllers/AttendanceController.php
+++ b/app/Http/Controllers/AttendanceController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use App\Models\Employee;
+use App\Models\AttendanceLog;
+
+class AttendanceController extends Controller
+{
+    public function checkIn(Request $request)
+    {
+        $user = auth('api')->user();
+        $emp = Employee::where('user_id', $user->id)->first();
+        if (! $emp) {
+            return response()->json(['message' => 'Employee not bound'], 422);
+        }
+
+        $today = Carbon::now()->toDateString();
+        $log = AttendanceLog::firstOrCreate(
+            ['employee_id' => $emp->id, 'work_date' => $today],
+            ['status' => 'normal']
+        );
+        if (! $log->check_in_at) {
+            $log->check_in_at = Carbon::now();
+            $log->save();
+        }
+        return response()->json($log->fresh());
+    }
+
+    public function checkOut(Request $request)
+    {
+        $user = auth('api')->user();
+        $emp = Employee::where('user_id', $user->id)->first();
+        if (! $emp) {
+            return response()->json(['message' => 'Employee not bound'], 422);
+        }
+
+        $today = Carbon::now()->toDateString();
+        $log = AttendanceLog::where('employee_id', $emp->id)
+            ->where('work_date', $today)
+            ->first();
+        if (! $log) {
+            $log = AttendanceLog::create([
+                'employee_id' => $emp->id,
+                'work_date' => $today,
+                'status' => 'normal',
+                'check_out_at' => Carbon::now(),
+            ]);
+        } else {
+            $log->check_out_at = Carbon::now();
+            $log->save();
+        }
+        return response()->json($log->fresh());
+    }
+
+    public function myLogs(Request $request)
+    {
+        $user = auth('api')->user();
+        $emp = Employee::where('user_id', $user->id)->first();
+        if (! $emp) {
+            return response()->json(['data' => [], 'total' => 0]);
+        }
+
+        $q = AttendanceLog::where('employee_id', $emp->id);
+
+        if ($request->filled('date_from')) {
+            $q->whereDate('work_date', '>=', $request->date('date_from'));
+        }
+        if ($request->filled('date_to')) {
+            $q->whereDate('work_date', '<=', $request->date('date_to'));
+        }
+
+        $logs = $q->orderByDesc('work_date')->paginate($request->integer('per_page', 20));
+        return response()->json($logs);
+    }
+}

--- a/app/Models/AttendanceLog.php
+++ b/app/Models/AttendanceLog.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class AttendanceLog extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'employee_id',
+        'work_date',
+        'status',
+        'check_in_at',
+        'check_out_at',
+    ];
+
+    protected $casts = [
+        'work_date' => 'date',
+        'check_in_at' => 'datetime',
+        'check_out_at' => 'datetime',
+    ];
+
+    public function employee()
+    {
+        return $this->belongsTo(Employee::class);
+    }
+}

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Employee extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'name',
+    ];
+
+    public function logs()
+    {
+        return $this->hasMany(AttendanceLog::class);
+    }
+}

--- a/database/migrations/2024_01_01_000003_create_employees_table.php
+++ b/database/migrations/2024_01_01_000003_create_employees_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('employees', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('name')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('employees');
+    }
+};

--- a/database/migrations/2024_01_01_000004_create_attendance_logs_table.php
+++ b/database/migrations/2024_01_01_000004_create_attendance_logs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('attendance_logs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('employee_id')->constrained()->cascadeOnDelete();
+            $table->date('work_date');
+            $table->string('status')->default('normal');
+            $table->timestamp('check_in_at')->nullable();
+            $table->timestamp('check_out_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('attendance_logs');
+    }
+};


### PR DESCRIPTION
## Summary
- implement attendance check-in/out and log retrieval endpoints
- add Employee and AttendanceLog models and migrations

## Testing
- `composer install` (fails: requires GitHub token)
- `php artisan test` (fails: missing vendor/autoload.php)


------
https://chatgpt.com/codex/tasks/task_e_68baa1967de8833095360684d345b04e