### PR TITLE
Add leave request APIs

### DIFF
--- a/app/Http/Controllers/LeavesController.php
+++ b/app/Http/Controllers/LeavesController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Employee;
+use App\Models\LeaveRequest;
+
+class LeavesController extends Controller
+{
+    public function index(Request $r)
+    {
+        $emp = Employee::where('user_id', auth('api')->id())->first();
+        if (!$emp) return response()->json(['data'=>[],'total'=>0]);
+
+        $q = LeaveRequest::where('employee_id',$emp->id);
+        if ($r->filled('status')) $q->where('status',$r->string('status'));
+        return response()->json($q->orderByDesc('id')->paginate($r->integer('per_page',20)));
+    }
+
+    public function store(Request $r)
+    {
+        $emp = Employee::where('user_id', auth('api')->id())->firstOrFail();
+        $data = $r->validate([
+            'type'=>['required','in:annual,sick,unpaid,other'],
+            'start_at'=>['required','date'],
+            'end_at'=>['required','date','after_or_equal:start_at'],
+            'reason'=>['nullable','string'],
+        ]);
+        $data['employee_id'] = $emp->id;
+        $leave = LeaveRequest::create($data);
+        return response()->json($leave, 201);
+    }
+
+    public function cancel($id)
+    {
+        $emp = Employee::where('user_id', auth('api')->id())->firstOrFail();
+        $leave = LeaveRequest::where('employee_id',$emp->id)->findOrFail($id);
+        if ($leave->status !== 'pending') {
+            return response()->json(['message'=>'Only pending can be cancelled'], 422);
+        }
+        $leave->status = 'rejected';
+        $leave->save();
+        return $leave->fresh();
+    }
+}

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -18,4 +18,9 @@ class Employee extends Model
     {
         return $this->hasMany(AttendanceLog::class);
     }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/app/Models/LeaveRequest.php
+++ b/app/Models/LeaveRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class LeaveRequest extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'employee_id',
+        'type',
+        'start_at',
+        'end_at',
+        'reason',
+        'status',
+    ];
+
+    protected $casts = [
+        'start_at' => 'date',
+        'end_at' => 'date',
+    ];
+
+    public function employee()
+    {
+        return $this->belongsTo(Employee::class);
+    }
+}

--- a/database/factories/EmployeeFactory.php
+++ b/database/factories/EmployeeFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Employee>
+ */
+class EmployeeFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'name' => fake()->name(),
+        ];
+    }
+}

--- a/database/factories/LeaveRequestFactory.php
+++ b/database/factories/LeaveRequestFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Employee;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Carbon;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\LeaveRequest>
+ */
+class LeaveRequestFactory extends Factory
+{
+    public function definition(): array
+    {
+        $start = Carbon::today();
+        $end = (clone $start)->addDays(fake()->numberBetween(0, 5));
+        return [
+            'employee_id' => Employee::factory(),
+            'type' => fake()->randomElement(['annual', 'sick', 'unpaid', 'other']),
+            'start_at' => $start,
+            'end_at' => $end,
+            'reason' => fake()->optional()->sentence(),
+            'status' => 'pending',
+        ];
+    }
+}

--- a/database/migrations/2024_01_01_000005_create_leave_requests_table.php
+++ b/database/migrations/2024_01_01_000005_create_leave_requests_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('leave_requests', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('employee_id')->constrained()->cascadeOnDelete();
+            $table->string('type');
+            $table->date('start_at');
+            $table->date('end_at');
+            $table->text('reason')->nullable();
+            $table->string('status')->default('pending');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('leave_requests');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\AttendanceController;
+use App\Http\Controllers\LeavesController;
 
 Route::post('/auth/login', [AuthController::class, 'login']);
 Route::middleware('auth:api')->group(function () {
@@ -12,4 +13,8 @@ Route::middleware('auth:api')->group(function () {
     Route::post('/attendance/check-in', [AttendanceController::class, 'checkIn']);
     Route::post('/attendance/check-out', [AttendanceController::class, 'checkOut']);
     Route::get('/attendance/my', [AttendanceController::class, 'myLogs']);
+
+    Route::get('/leaves/my', [LeavesController::class, 'index']);
+    Route::post('/leaves', [LeavesController::class, 'store']);
+    Route::put('/leaves/{id}/cancel', [LeavesController::class, 'cancel']);
 });

--- a/tests/Feature/LeavesControllerTest.php
+++ b/tests/Feature/LeavesControllerTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Employee;
+use App\Models\LeaveRequest;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LeavesControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function actingAsUser(User $user)
+    {
+        $token = auth('api')->login($user);
+        return $this->withHeader('Authorization', 'Bearer ' . $token);
+    }
+
+    public function test_index_returns_paginated_leaves()
+    {
+        $employee = Employee::factory()->create();
+        LeaveRequest::factory()->count(3)->create(['employee_id' => $employee->id]);
+        // another employee's leaves shouldn't show
+        LeaveRequest::factory()->count(2)->create();
+
+        $client = $this->actingAsUser($employee->user);
+        $response = $client->getJson('/api/leaves/my');
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'total' => 3,
+            ]);
+        $this->assertCount(3, $response->json('data'));
+    }
+
+    public function test_store_creates_leave_request()
+    {
+        $employee = Employee::factory()->create();
+        $payload = [
+            'type' => 'annual',
+            'start_at' => now()->toDateString(),
+            'end_at' => now()->addDay()->toDateString(),
+            'reason' => 'vacation',
+        ];
+
+        $client = $this->actingAsUser($employee->user);
+        $response = $client->postJson('/api/leaves', $payload);
+
+        $response->assertStatus(201)
+            ->assertJsonFragment([
+                'type' => 'annual',
+                'reason' => 'vacation',
+                'status' => 'pending',
+            ]);
+
+        $this->assertDatabaseHas('leave_requests', [
+            'employee_id' => $employee->id,
+            'type' => 'annual',
+            'reason' => 'vacation',
+        ]);
+    }
+
+    public function test_cancel_only_pending()
+    {
+        $employee = Employee::factory()->create();
+        $pending = LeaveRequest::factory()->create(['employee_id' => $employee->id]);
+        $approved = LeaveRequest::factory()->create(['employee_id' => $employee->id, 'status' => 'approved']);
+
+        $client = $this->actingAsUser($employee->user);
+
+        $client->putJson("/api/leaves/{$pending->id}/cancel")
+            ->assertStatus(200)
+            ->assertJsonFragment(['status' => 'rejected']);
+
+        $client->putJson("/api/leaves/{$approved->id}/cancel")
+            ->assertStatus(422)
+            ->assertJson(['message' => 'Only pending can be cancelled']);
+    }
+}


### PR DESCRIPTION
## Summary
- add `LeavesController` for listing, submitting, and cancelling leave requests
- create `LeaveRequest` model, migration, and factories
- expose leave endpoints and related tests

## Testing
- `php artisan test` *(fails: require vendor/autoload.php; Composer install failed due to GitHub authentication requirements)*

------
https://chatgpt.com/codex/tasks/task_e_68bacae07874833099ddff38c568ad57