### PR TITLE
chore: set up react query provider

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_URL=http://127.0.0.1:8002/api

--- a/package.json
+++ b/package.json
@@ -6,9 +6,14 @@
         "build": "vite build",
         "dev": "vite"
     },
+    "dependencies": {
+        "@tanstack/react-query": "^5.0.0",
+        "axios": "^1.11.0",
+        "dayjs": "^1.11.10",
+        "sonner": "^1.0.0"
+    },
     "devDependencies": {
         "@tailwindcss/vite": "^4.0.0",
-        "axios": "^1.11.0",
         "concurrently": "^9.0.1",
         "laravel-vite-plugin": "^2.0.0",
         "tailwindcss": "^4.0.0",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,19 @@
+import './globals.css';
+import type { Metadata } from 'next';
+import QueryProvider from '@/lib/query';
+import { Toaster } from 'sonner';
+
+export const metadata: Metadata = { title: 'Attendance FE', description: 'Employee self-service' };
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-background text-foreground">
+        <QueryProvider>
+          {children}
+          <Toaster richColors closeButton />
+        </QueryProvider>
+      </body>
+    </html>
+  );
+}

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,0 +1,22 @@
+import axios from 'axios';
+
+export const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL,
+  timeout: 15000,
+});
+
+api.interceptors.request.use(cfg=>{
+  if (typeof window !== 'undefined') {
+    const t = localStorage.getItem('access_token');
+    if (t) cfg.headers.Authorization = `Bearer ${t}`;
+  }
+  return cfg;
+});
+
+api.interceptors.response.use(r=>r, err=>{
+  if (err?.response?.status === 401 && typeof window !== 'undefined') {
+    localStorage.removeItem('access_token');
+    location.href = '/login';
+  }
+  return Promise.reject(err);
+});

--- a/src/lib/query.tsx
+++ b/src/lib/query.tsx
@@ -1,0 +1,8 @@
+'use client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { PropsWithChildren, useState } from 'react';
+
+export default function QueryProvider({ children }: PropsWithChildren) {
+  const [client] = useState(()=>new QueryClient());
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}


### PR DESCRIPTION
## Summary
- configure axios instance with auth token handling
- add React Query provider and global Toaster to layout
- expose API url through `.env.local`
- add react-query, axios, dayjs and sonner dependencies

## Testing
- `npm run build`
- `npm i @tanstack/react-query axios dayjs sonner` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68badecf0f6c8330bb0f5631ac40da22