### PR TITLE
feat: add home page check-in functionality

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,0 +1,49 @@
+'use client';
+import Shell from '@/components/Shell';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { api } from '@/lib/axios';
+import dayjs from 'dayjs';
+import { toast } from 'sonner';
+
+export default function HomePage(){
+  const qc = useQueryClient();
+  const today = dayjs().format('YYYY-MM-DD');
+
+  const { data, isFetching } = useQuery({
+    queryKey: ['my-today', today],
+    queryFn: async ()=>{
+      const res = await api.get('/attendance/my', { params: { date_from: today, date_to: today, per_page: 1 }});
+      return res.data;
+    }
+  });
+
+  const checkIn = useMutation({
+    mutationFn: async ()=> (await api.post('/attendance/check-in')).data,
+    onSuccess: ()=>{ toast.success('Checked in'); qc.invalidateQueries({queryKey:['my-today', today]}); }
+  });
+  const checkOut = useMutation({
+    mutationFn: async ()=> (await api.post('/attendance/check-out')).data,
+    onSuccess: ()=>{ toast.success('Checked out'); qc.invalidateQueries({queryKey:['my-today', today]}); }
+  });
+
+  const log = data?.data?.[0];
+
+  return (
+    <Shell title="Home">
+      <div className="space-y-4">
+        <div className="text-lg font-semibold">Today: {today}</div>
+        {isFetching ? <div>Loading...</div> : (
+          <div className="space-y-2 border rounded-xl p-4">
+            <div>Check In: <b>{log?.check_in_at || '-'}</b></div>
+            <div>Check Out: <b>{log?.check_out_at || '-'}</b></div>
+            <div>Status: <b>{log?.status || 'N/A'}</b></div>
+          </div>
+        )}
+        <div className="flex gap-2">
+          <button onClick={()=>checkIn.mutate()} className="px-4 py-2 rounded bg-black text-white">Check In</button>
+          <button onClick={()=>checkOut.mutate()} className="px-4 py-2 rounded border">Check Out</button>
+        </div>
+      </div>
+    </Shell>
+  );
+}

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -1,0 +1,17 @@
+'use client';
+export default function Shell({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="max-w-4xl mx-auto p-6">
+      <header className="flex items-center justify-between mb-6">
+        <h1 className="text-xl font-semibold">{title}</h1>
+        <button
+          className="px-3 py-1.5 rounded border"
+          onClick={() => { localStorage.removeItem('access_token'); location.href='/login'; }}
+        >
+          Logout
+        </button>
+      </header>
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Shell layout component with logout button
- implement Home page to view today's attendance and trigger check-in/out

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bae20fef0483308011fc9b042bf218