### PR TITLE
feat: add profile page

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,23 @@
+'use client';
+import Shell from '@/components/Shell';
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/lib/axios';
+
+export default function ProfilePage(){
+  const { data, isFetching } = useQuery({
+    queryKey: ['me'],
+    queryFn: async ()=> (await api.get('/auth/me')).data
+  });
+
+  return (
+    <Shell title="Profile">
+      {isFetching ? <div>Loading...</div> : (
+        <div className="space-y-2 border rounded-xl p-4">
+          <div><b>Name:</b> {data?.name}</div>
+          <div><b>Email:</b> {data?.email}</div>
+          <div className="text-sm text-neutral-500">This data comes from `/auth/me`</div>
+        </div>
+      )}
+    </Shell>
+  );
+}


### PR DESCRIPTION
## Summary
- add profile page to show authenticated user info

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bae633717083308827c0229ba90e03