### PR TITLE
feat: polish UX components

### DIFF
--- a/src/app/attendance/page.tsx
+++ b/src/app/attendance/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import Shell from '@/components/Shell';
+import State from '@/components/State';
 import { useQuery } from '@tanstack/react-query';
 import { api } from '@/lib/axios';
 import dayjs from 'dayjs';
@@ -22,13 +23,13 @@ export default function MyAttendancePage(){
     <Shell title="My Attendance">
       <div className="space-y-3">
         <div className="flex flex-wrap gap-2">
-          <input type="date" value={from} onChange={e=>setFrom(e.target.value)} className="border rounded px-3 py-2" />
-          <input type="date" value={to} onChange={e=>setTo(e.target.value)} className="border rounded px-3 py-2" />
-          <button onClick={()=>{ setPage(1); refetch(); }} className="px-4 py-2 rounded border">Filter</button>
+          <input type="date" value={from} onChange={e=>setFrom(e.target.value)} className="border rounded-xl px-3 py-2" />
+          <input type="date" value={to} onChange={e=>setTo(e.target.value)} className="border rounded-xl px-3 py-2" />
+          <button onClick={()=>{ setPage(1); refetch(); }} className="px-4 py-2 rounded-xl border">Filter</button>
         </div>
 
-        {isFetching ? <div>Loading...</div> : (
-          <div className="overflow-x-auto border rounded-xl">
+        {isFetching ? <State type="loading" /> : (
+          <div className="overflow-x-auto border rounded-xl shadow-sm">
             <table className="w-full text-sm">
               <thead>
                 <tr className="bg-neutral-50">
@@ -47,16 +48,20 @@ export default function MyAttendancePage(){
                     <td className="p-2">{row.status}</td>
                   </tr>
                 ))}
-                {!data?.data?.length && <tr><td colSpan={4} className="p-3 text-center text-neutral-500">No data</td></tr>}
+                {!data?.data?.length && (
+                  <tr>
+                    <td colSpan={4}><State type="empty" /></td>
+                  </tr>
+                )}
               </tbody>
             </table>
           </div>
         )}
 
         <div className="flex items-center gap-2">
-          <button disabled={page<=1} onClick={()=>setPage(p=>p-1)} className="px-3 py-1.5 rounded border disabled:opacity-50">Prev</button>
+          <button disabled={page<=1} onClick={()=>setPage(p=>p-1)} className="px-3 py-1.5 rounded-xl border disabled:opacity-50">Prev</button>
           <span>Page {data?.current_page || page}</span>
-          <button disabled={!data?.next_page_url} onClick={()=>setPage(p=>p+1)} className="px-3 py-1.5 rounded border disabled:opacity-50">Next</button>
+          <button disabled={!data?.next_page_url} onClick={()=>setPage(p=>p+1)} className="px-3 py-1.5 rounded-xl border disabled:opacity-50">Next</button>
         </div>
       </div>
     </Shell>

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import Shell from '@/components/Shell';
+import State from '@/components/State';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '@/lib/axios';
 import dayjs from 'dayjs';
@@ -32,16 +33,16 @@ export default function HomePage(){
     <Shell title="Home">
       <div className="space-y-4">
         <div className="text-lg font-semibold">Today: {today}</div>
-        {isFetching ? <div>Loading...</div> : (
-          <div className="space-y-2 border rounded-xl p-4">
+        {isFetching ? <State type="loading" /> : (
+          <div className="space-y-2 border rounded-xl p-4 shadow-sm">
             <div>Check In: <b>{log?.check_in_at || '-'}</b></div>
             <div>Check Out: <b>{log?.check_out_at || '-'}</b></div>
             <div>Status: <b>{log?.status || 'N/A'}</b></div>
           </div>
         )}
         <div className="flex gap-2">
-          <button onClick={()=>checkIn.mutate()} className="px-4 py-2 rounded bg-black text-white">Check In</button>
-          <button onClick={()=>checkOut.mutate()} className="px-4 py-2 rounded border">Check Out</button>
+          <button onClick={()=>checkIn.mutate()} className="px-4 py-2 rounded-xl bg-black text-white">Check In</button>
+          <button onClick={()=>checkOut.mutate()} className="px-4 py-2 rounded-xl border">Check Out</button>
         </div>
       </div>
     </Shell>

--- a/src/app/leaves/page.tsx
+++ b/src/app/leaves/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import Shell from '@/components/Shell';
+import State from '@/components/State';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '@/lib/axios';
 import { useState } from 'react';
@@ -39,7 +40,7 @@ export default function MyLeavesPage(){
     <Shell title="My Leaves">
       <div className="space-y-4">
         <div className="flex flex-wrap gap-2">
-          <select value={status} onChange={e=>{setStatus(e.target.value); setPage(1);}} className="border rounded px-3 py-2">
+          <select value={status} onChange={e=>{setStatus(e.target.value); setPage(1);}} className="border rounded-xl px-3 py-2">
             <option value="">All</option>
             <option value="pending">Pending</option>
             <option value="approved">Approved</option>
@@ -47,29 +48,29 @@ export default function MyLeavesPage(){
           </select>
         </div>
 
-        <div className="border rounded-xl p-4 space-y-2">
+        <div className="border rounded-xl p-4 space-y-2 shadow-sm">
           <div className="font-medium">New Leave</div>
           <div className="grid grid-cols-1 md:grid-cols-4 gap-2">
-            <select value={type} onChange={e=>setType(e.target.value)} className="border rounded px-3 py-2">
+            <select value={type} onChange={e=>setType(e.target.value)} className="border rounded-xl px-3 py-2">
               <option value="annual">Annual</option>
               <option value="sick">Sick</option>
               <option value="unpaid">Unpaid</option>
               <option value="other">Other</option>
             </select>
-            <input value={startAt} onChange={e=>setStartAt(e.target.value)} className="border rounded px-3 py-2" placeholder="YYYY-MM-DD HH:mm:ss"/>
-            <input value={endAt} onChange={e=>setEndAt(e.target.value)} className="border rounded px-3 py-2" placeholder="YYYY-MM-DD HH:mm:ss"/>
-            <input value={reason} onChange={e=>setReason(e.target.value)} className="border rounded px-3 py-2" placeholder="Reason(optional)"/>
+            <input value={startAt} onChange={e=>setStartAt(e.target.value)} className="border rounded-xl px-3 py-2" placeholder="YYYY-MM-DD HH:mm:ss"/>
+            <input value={endAt} onChange={e=>setEndAt(e.target.value)} className="border rounded-xl px-3 py-2" placeholder="YYYY-MM-DD HH:mm:ss"/>
+            <input value={reason} onChange={e=>setReason(e.target.value)} className="border rounded-xl px-3 py-2" placeholder="Reason(optional)"/>
           </div>
           <button
-            className="px-4 py-2 rounded bg-black text-white"
+            className="px-4 py-2 rounded-xl bg-black text-white"
             onClick={()=>createLeave.mutate({ type, start_at: startAt, end_at: endAt, reason })}
           >
             Submit
           </button>
         </div>
 
-        {isFetching ? <div>Loading...</div> : (
-          <div className="overflow-x-auto border rounded-xl">
+        {isFetching ? <State type="loading" /> : (
+          <div className="overflow-x-auto border rounded-xl shadow-sm">
             <table className="w-full text-sm">
               <thead>
                 <tr className="bg-neutral-50">
@@ -91,21 +92,25 @@ export default function MyLeavesPage(){
                     <td className="p-2">{row.status}</td>
                     <td className="p-2">
                       {row.status==='pending' ? (
-                        <button onClick={()=>cancelLeave.mutate(row.id)} className="px-3 py-1.5 rounded border">Cancel</button>
+                        <button onClick={()=>cancelLeave.mutate(row.id)} className="px-3 py-1.5 rounded-xl border">Cancel</button>
                       ) : <span className="text-neutral-400">-</span>}
                     </td>
                   </tr>
                 ))}
-                {!data?.data?.length && <tr><td colSpan={6} className="p-3 text-center text-neutral-500">No data</td></tr>}
+                {!data?.data?.length && (
+                  <tr>
+                    <td colSpan={6}><State type="empty" /></td>
+                  </tr>
+                )}
               </tbody>
             </table>
           </div>
         )}
 
         <div className="flex items-center gap-2">
-          <button disabled={page<=1} onClick={()=>setPage(p=>p-1)} className="px-3 py-1.5 rounded border disabled:opacity-50">Prev</button>
+          <button disabled={page<=1} onClick={()=>setPage(p=>p-1)} className="px-3 py-1.5 rounded-xl border disabled:opacity-50">Prev</button>
           <span>Page {data?.current_page || page}</span>
-          <button disabled={!data?.next_page_url} onClick={()=>setPage(p=>p+1)} className="px-3 py-1.5 rounded border disabled:opacity-50">Next</button>
+          <button disabled={!data?.next_page_url} onClick={()=>setPage(p=>p+1)} className="px-3 py-1.5 rounded-xl border disabled:opacity-50">Next</button>
         </div>
       </div>
     </Shell>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -26,12 +26,12 @@ export default function Login() {
   }
 
   return (
-    <form onSubmit={onSubmit} className="min-h-screen grid place-items-center p-6">
-      <div className="space-y-3 border p-6 rounded-xl w-full max-w-sm">
+    <form onSubmit={onSubmit} className="min-h-screen grid place-items-center p-4 sm:p-6">
+      <div className="space-y-3 border p-6 rounded-xl w-full max-w-sm shadow-sm">
         <h1 className="text-xl font-semibold">Employee Login</h1>
-        <input className="border rounded px-3 py-2 w-full" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
-        <input className="border rounded px-3 py-2 w-full" type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
-        <button className="w-full bg-black text-white rounded py-2 disabled:opacity-50" disabled={loading}>
+        <input className="border rounded-xl px-3 py-2 w-full" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
+        <input className="border rounded-xl px-3 py-2 w-full" type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
+        <button className="w-full bg-black text-white rounded-xl py-2 disabled:opacity-50" disabled={loading}>
           {loading ? 'Signing in...' : 'Sign in'}
         </button>
       </div>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import Shell from '@/components/Shell';
+import State from '@/components/State';
 import { useQuery } from '@tanstack/react-query';
 import { api } from '@/lib/axios';
 
@@ -11,8 +12,8 @@ export default function ProfilePage(){
 
   return (
     <Shell title="Profile">
-      {isFetching ? <div>Loading...</div> : (
-        <div className="space-y-2 border rounded-xl p-4">
+      {isFetching ? <State type="loading" /> : (
+        <div className="space-y-2 border rounded-xl p-4 shadow-sm">
           <div><b>Name:</b> {data?.name}</div>
           <div><b>Email:</b> {data?.email}</div>
           <div className="text-sm text-neutral-500">This data comes from `/auth/me`</div>

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -1,16 +1,22 @@
 'use client';
 export default function Shell({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div className="max-w-4xl mx-auto p-6">
-      <header className="flex items-center justify-between mb-6">
-        <h1 className="text-xl font-semibold">{title}</h1>
+    <div className="max-w-4xl mx-auto p-4 sm:p-6">
+      <header className="flex items-center justify-between mb-4">
+        <nav className="flex gap-4 text-sm text-neutral-600">
+          <a href="/" className="hover:underline">Home</a>
+          <a href="/attendance" className="hover:underline">Attendance</a>
+          <a href="/leaves" className="hover:underline">Leaves</a>
+          <a href="/profile" className="hover:underline">Profile</a>
+        </nav>
         <button
-          className="px-3 py-1.5 rounded border"
+          className="px-3 py-1.5 rounded-xl border"
           onClick={() => { localStorage.removeItem('access_token'); location.href='/login'; }}
         >
           Logout
         </button>
       </header>
+      <h1 className="text-xl font-semibold mb-6">{title}</h1>
       {children}
     </div>
   );

--- a/src/components/State.tsx
+++ b/src/components/State.tsx
@@ -1,0 +1,15 @@
+'use client';
+type StateType = 'loading' | 'empty' | 'error';
+export default function State({ type, message }: { type: StateType; message?: string }) {
+  const defaults: Record<StateType, string> = {
+    loading: 'Loading...',
+    empty: 'No data',
+    error: 'Something went wrong',
+  };
+  const colors: Record<StateType, string> = {
+    loading: 'text-neutral-500',
+    empty: 'text-neutral-500',
+    error: 'text-red-500',
+  };
+  return <div className={`p-4 text-center ${colors[type]}`}>{message || defaults[type]}</div>;
+}


### PR DESCRIPTION
## Summary
- add reusable state component for loading, empty, and error views
- unify rounded corners, card shadows, mobile padding
- add simple top navigation and logout button styling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `php vendor/bin/phpunit` *(fails: Could not open input file: vendor/bin/phpunit)*

------
https://chatgpt.com/codex/tasks/task_e_68bae7273fbc8330a0f92d8b4109af06