### PR TITLE
fix: implement JWTSubject for user model

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,8 +6,9 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Tymon\JWTAuth\Contracts\JWTSubject;
 
-class User extends Authenticatable
+class User extends Authenticatable implements JWTSubject
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
     use HasFactory, Notifiable;
@@ -44,5 +45,15 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    public function getJWTIdentifier()
+    {
+        return $this->getKey();
+    }
+
+    public function getJWTCustomClaims(): array
+    {
+        return [];
     }
 }


### PR DESCRIPTION
## Summary
- implement `JWTSubject` on `User` model
- verify JWT guard configuration and secret

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan config:clear` *(fails: Failed opening required 'vendor/autoload.php')*
- `php artisan cache:clear` *(fails: Failed opening required 'vendor/autoload.php')*
- `php artisan route:clear` *(fails: Failed opening required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68bb8384f5088330a5f93fe7ef669763