### PR TITLE
feat: add project and shift browsing APIs

### DIFF
--- a/app/Http/Controllers/AnnouncementsController.php
+++ b/app/Http/Controllers/AnnouncementsController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Announcement;
+use Illuminate\Http\Request;
+
+class AnnouncementsController extends Controller
+{
+    public function feed(Request $r)
+    {
+        $q = Announcement::query();
+        if ($r->filled('project_id')) $q->where('project_id', $r->integer('project_id'));
+        if ($r->filled('after')) $q->where('created_at', '>', $r->date('after'));
+        return $q->orderByDesc('created_at')->limit(50)->get();
+    }
+}

--- a/app/Http/Controllers/ProjectsController.php
+++ b/app/Http/Controllers/ProjectsController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Project;
+use Illuminate\Http\Request;
+
+class ProjectsController extends Controller
+{
+    public function index(Request $r)
+    {
+        $q = Project::query();
+        if ($r->filled('active')) {
+            $q->where('active', $r->boolean('active'));
+        }
+        if ($r->filled('keyword')) {
+            $q->where('name', 'like', '%' . $r->string('keyword') . '%');
+        }
+        return $q->orderBy('name')->paginate($r->integer('per_page', 20));
+    }
+
+    public function locations($id)
+    {
+        $project = Project::findOrFail($id);
+        return $project->locations()->get();
+    }
+}

--- a/app/Http/Controllers/ShiftApplicationsController.php
+++ b/app/Http/Controllers/ShiftApplicationsController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Employee;
+use App\Models\ShiftApplication;
+use Illuminate\Http\Request;
+
+class ShiftApplicationsController extends Controller
+{
+    protected function employee()
+    {
+        return Employee::where('user_id', auth('api')->id())->firstOrFail();
+    }
+
+    public function store(Request $r)
+    {
+        $emp = $this->employee();
+        $data = $r->validate([
+            'shift_instance_id' => ['required', 'exists:shift_instances,id'],
+        ]);
+        $application = ShiftApplication::firstOrCreate(
+            ['employee_id' => $emp->id, 'shift_instance_id' => $data['shift_instance_id']],
+            ['status' => 'pending']
+        );
+        $status = $application->wasRecentlyCreated ? 201 : 200;
+        return response()->json($application, $status);
+    }
+
+    public function my(Request $r)
+    {
+        $emp = $this->employee();
+        $q = ShiftApplication::where('employee_id', $emp->id);
+        if ($r->filled('status')) $q->where('status', $r->string('status'));
+        return $q->orderByDesc('id')->paginate($r->integer('per_page', 20));
+    }
+
+    public function cancel($id)
+    {
+        $emp = $this->employee();
+        $app = ShiftApplication::where('employee_id', $emp->id)->findOrFail($id);
+        if ($app->status !== 'pending') {
+            return response()->json(['message' => 'Only pending can be cancelled'], 422);
+        }
+        $app->status = 'cancelled';
+        $app->save();
+        return $app->fresh();
+    }
+}

--- a/app/Http/Controllers/ShiftInstancesController.php
+++ b/app/Http/Controllers/ShiftInstancesController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ShiftInstance;
+use Illuminate\Http\Request;
+
+class ShiftInstancesController extends Controller
+{
+    public function index(Request $r)
+    {
+        $q = ShiftInstance::query();
+        if ($r->filled('project_id')) $q->where('project_id', $r->integer('project_id'));
+        if ($r->filled('location_id')) $q->where('location_id', $r->integer('location_id'));
+        if ($r->filled('date_from')) $q->whereDate('start_at', '>=', $r->date('date_from'));
+        if ($r->filled('date_to')) $q->whereDate('start_at', '<=', $r->date('date_to'));
+        return $q->orderBy('start_at')->paginate($r->integer('per_page', 20));
+    }
+}

--- a/app/Models/Announcement.php
+++ b/app/Models/Announcement.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Announcement extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['project_id', 'content'];
+
+    public function project()
+    {
+        return $this->belongsTo(Project::class);
+    }
+}

--- a/app/Models/Location.php
+++ b/app/Models/Location.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int $id
+ * @property int $project_id
+ * @property string $name
+ */
+class Location extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['project_id', 'name'];
+
+    public function project()
+    {
+        return $this->belongsTo(Project::class);
+    }
+
+    public function shiftInstances()
+    {
+        return $this->hasMany(ShiftInstance::class);
+    }
+}

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int $id
+ * @property string $name
+ * @property bool $active
+ */
+class Project extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['name', 'active'];
+
+    protected $casts = [
+        'active' => 'boolean',
+    ];
+
+    public function locations()
+    {
+        return $this->hasMany(Location::class);
+    }
+
+    public function shiftInstances()
+    {
+        return $this->hasMany(ShiftInstance::class);
+    }
+
+    public function announcements()
+    {
+        return $this->hasMany(Announcement::class);
+    }
+}

--- a/app/Models/ShiftApplication.php
+++ b/app/Models/ShiftApplication.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int $id
+ * @property int $employee_id
+ * @property int $shift_instance_id
+ * @property string $status
+ */
+class ShiftApplication extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['employee_id', 'shift_instance_id', 'status'];
+
+    public function employee()
+    {
+        return $this->belongsTo(Employee::class);
+    }
+
+    public function shiftInstance()
+    {
+        return $this->belongsTo(ShiftInstance::class);
+    }
+}

--- a/app/Models/ShiftInstance.php
+++ b/app/Models/ShiftInstance.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int $id
+ * @property int $project_id
+ * @property int $location_id
+ * @property \DateTimeInterface $start_at
+ * @property \DateTimeInterface $end_at
+ */
+class ShiftInstance extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['project_id', 'location_id', 'start_at', 'end_at'];
+
+    protected $casts = [
+        'start_at' => 'datetime',
+        'end_at' => 'datetime',
+    ];
+
+    public function project()
+    {
+        return $this->belongsTo(Project::class);
+    }
+
+    public function location()
+    {
+        return $this->belongsTo(Location::class);
+    }
+
+    public function applications()
+    {
+        return $this->hasMany(ShiftApplication::class);
+    }
+}

--- a/database/factories/AnnouncementFactory.php
+++ b/database/factories/AnnouncementFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Project;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Announcement>
+ */
+class AnnouncementFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'project_id' => Project::factory(),
+            'content' => $this->faker->sentence(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ];
+    }
+}

--- a/database/factories/LocationFactory.php
+++ b/database/factories/LocationFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Project;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Location>
+ */
+class LocationFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'project_id' => Project::factory(),
+            'name' => $this->faker->city(),
+        ];
+    }
+}

--- a/database/factories/ProjectFactory.php
+++ b/database/factories/ProjectFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Project>
+ */
+class ProjectFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->words(2, true),
+            'active' => true,
+        ];
+    }
+}

--- a/database/factories/ShiftApplicationFactory.php
+++ b/database/factories/ShiftApplicationFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Employee;
+use App\Models\ShiftInstance;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\ShiftApplication>
+ */
+class ShiftApplicationFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'employee_id' => Employee::factory(),
+            'shift_instance_id' => ShiftInstance::factory(),
+            'status' => 'pending',
+        ];
+    }
+}

--- a/database/factories/ShiftInstanceFactory.php
+++ b/database/factories/ShiftInstanceFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Location;
+use App\Models\Project;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\ShiftInstance>
+ */
+class ShiftInstanceFactory extends Factory
+{
+    public function definition(): array
+    {
+        $start = $this->faker->dateTimeBetween('+1 days', '+10 days');
+        $end = (clone $start)->modify('+8 hours');
+        $project = Project::factory();
+        return [
+            'project_id' => $project,
+            'location_id' => Location::factory()->for($project),
+            'start_at' => $start,
+            'end_at' => $end,
+        ];
+    }
+}

--- a/database/migrations/2024_01_01_000001_create_projects_table.php
+++ b/database/migrations/2024_01_01_000001_create_projects_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('projects', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->boolean('active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('projects');
+    }
+};

--- a/database/migrations/2024_01_01_000002_create_locations_table.php
+++ b/database/migrations/2024_01_01_000002_create_locations_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('locations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('project_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('locations');
+    }
+};

--- a/database/migrations/2024_01_01_000003_create_shift_instances_table.php
+++ b/database/migrations/2024_01_01_000003_create_shift_instances_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('shift_instances', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('project_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('location_id')->constrained()->cascadeOnDelete();
+            $table->dateTime('start_at');
+            $table->dateTime('end_at');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('shift_instances');
+    }
+};

--- a/database/migrations/2024_01_01_000004_create_shift_applications_table.php
+++ b/database/migrations/2024_01_01_000004_create_shift_applications_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('shift_applications', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('employee_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('shift_instance_id')->constrained()->cascadeOnDelete();
+            $table->string('status')->default('pending');
+            $table->timestamps();
+            $table->unique(['employee_id', 'shift_instance_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('shift_applications');
+    }
+};

--- a/database/migrations/2024_01_01_000005_create_announcements_table.php
+++ b/database/migrations/2024_01_01_000005_create_announcements_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('announcements', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('project_id')->nullable()->constrained()->cascadeOnDelete();
+            $table->text('content');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('announcements');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,6 +4,10 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\AttendanceController;
 use App\Http\Controllers\LeavesController;
+use App\Http\Controllers\ProjectsController;
+use App\Http\Controllers\ShiftInstancesController;
+use App\Http\Controllers\ShiftApplicationsController;
+use App\Http\Controllers\AnnouncementsController;
 
 Route::post('/auth/login', [AuthController::class, 'login']);
 Route::middleware('auth:api')->group(function () {
@@ -17,4 +21,15 @@ Route::middleware('auth:api')->group(function () {
     Route::get('/leaves/my', [LeavesController::class, 'index']);
     Route::post('/leaves', [LeavesController::class, 'store']);
     Route::put('/leaves/{id}/cancel', [LeavesController::class, 'cancel']);
+
+    Route::get('/projects', [ProjectsController::class, 'index']);
+    Route::get('/projects/{id}/locations', [ProjectsController::class, 'locations']);
+
+    Route::get('/shift-instances', [ShiftInstancesController::class, 'index']);
+
+    Route::post('/shift-applications', [ShiftApplicationsController::class, 'store']);
+    Route::get('/shift-applications/my', [ShiftApplicationsController::class, 'my']);
+    Route::put('/shift-applications/{id}/cancel', [ShiftApplicationsController::class, 'cancel']);
+
+    Route::get('/announcements/feed', [AnnouncementsController::class, 'feed']);
 });

--- a/tests/Feature/AnnouncementsControllerTest.php
+++ b/tests/Feature/AnnouncementsControllerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Announcement;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AnnouncementsControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function actingAs(User $user)
+    {
+        $token = auth('api')->login($user);
+        return $this->withHeader('Authorization', 'Bearer ' . $token);
+    }
+
+    public function test_feed_filters_and_orders()
+    {
+        $project = Project::factory()->create();
+        Announcement::factory()->create(['project_id' => $project->id, 'created_at' => now()->subDay(), 'content' => 'old']);
+        Announcement::factory()->create(['project_id' => $project->id, 'created_at' => now(), 'content' => 'new']);
+        Announcement::factory()->create();
+
+        $client = $this->actingAs(User::factory()->create());
+        $res = $client->getJson('/api/announcements/feed?project_id=' . $project->id);
+        $res->assertStatus(200);
+        $this->assertCount(2, $res->json());
+        $this->assertEquals('new', $res->json()[0]['content']);
+
+        $res2 = $client->getJson('/api/announcements/feed?project_id=' . $project->id . '&after=' . now()->toDateTimeString());
+        $res2->assertStatus(200);
+        $this->assertCount(0, $res2->json());
+    }
+}

--- a/tests/Feature/ProjectsControllerTest.php
+++ b/tests/Feature/ProjectsControllerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ProjectsControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function actingAs(User $user)
+    {
+        $token = auth('api')->login($user);
+        return $this->withHeader('Authorization', 'Bearer ' . $token);
+    }
+
+    public function test_index_filters_active_and_keyword()
+    {
+        Project::factory()->create(['name' => 'Alpha', 'active' => true]);
+        Project::factory()->create(['name' => 'Beta', 'active' => true]);
+        Project::factory()->create(['name' => 'Gamma', 'active' => false]);
+
+        $client = $this->actingAs(User::factory()->create());
+        $res = $client->getJson('/api/projects?active=1&keyword=Al');
+        $res->assertStatus(200);
+        $data = $res->json('data');
+        $this->assertCount(1, $data);
+        $this->assertEquals('Alpha', $data[0]['name']);
+    }
+
+    public function test_locations_returns_locations()
+    {
+        $project = Project::factory()->hasLocations(2)->create();
+        Project::factory()->hasLocations(1)->create();
+
+        $client = $this->actingAs(User::factory()->create());
+        $res = $client->getJson("/api/projects/{$project->id}/locations");
+        $res->assertStatus(200);
+        $this->assertCount(2, $res->json());
+    }
+}

--- a/tests/Feature/ShiftApplicationsControllerTest.php
+++ b/tests/Feature/ShiftApplicationsControllerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Employee;
+use App\Models\ShiftApplication;
+use App\Models\ShiftInstance;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ShiftApplicationsControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function actingAs(Employee $employee)
+    {
+        $token = auth('api')->login($employee->user);
+        return $this->withHeader('Authorization', 'Bearer ' . $token);
+    }
+
+    public function test_store_is_idempotent_and_my_lists()
+    {
+        $employee = Employee::factory()->create();
+        $shift = ShiftInstance::factory()->create();
+        $client = $this->actingAs($employee);
+
+        $payload = ['shift_instance_id' => $shift->id];
+        $client->postJson('/api/shift-applications', $payload)
+            ->assertStatus(201);
+        $client->postJson('/api/shift-applications', $payload)
+            ->assertStatus(200);
+
+        $res = $client->getJson('/api/shift-applications/my');
+        $res->assertStatus(200);
+        $this->assertCount(1, $res->json('data'));
+    }
+
+    public function test_cancel_only_pending()
+    {
+        $employee = Employee::factory()->create();
+        $pending = ShiftApplication::factory()->create(['employee_id' => $employee->id]);
+        $approved = ShiftApplication::factory()->create(['employee_id' => $employee->id, 'status' => 'approved']);
+
+        $client = $this->actingAs($employee);
+        $client->putJson("/api/shift-applications/{$pending->id}/cancel")
+            ->assertStatus(200)
+            ->assertJsonFragment(['status' => 'cancelled']);
+
+        $client->putJson("/api/shift-applications/{$approved->id}/cancel")
+            ->assertStatus(422);
+    }
+}

--- a/tests/Feature/ShiftInstancesControllerTest.php
+++ b/tests/Feature/ShiftInstancesControllerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ShiftInstance;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ShiftInstancesControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function actingAs(User $user)
+    {
+        $token = auth('api')->login($user);
+        return $this->withHeader('Authorization', 'Bearer ' . $token);
+    }
+
+    public function test_index_filters_by_params()
+    {
+        $shiftA = ShiftInstance::factory()->create([
+            'start_at' => now()->addDays(2),
+        ]);
+        // Different location and project
+        ShiftInstance::factory()->create([
+            'project_id' => $shiftA->project_id,
+            'location_id' => $shiftA->location_id,
+            'start_at' => now()->addDays(5),
+        ]);
+        ShiftInstance::factory()->create();
+
+        $client = $this->actingAs(User::factory()->create());
+        $res = $client->getJson('/api/shift-instances?project_id=' . $shiftA->project_id . '&location_id=' . $shiftA->location_id . '&date_from=' . now()->addDay()->toDateString() . '&date_to=' . now()->addDays(3)->toDateString());
+        $res->assertStatus(200);
+        $this->assertCount(1, $res->json('data'));
+    }
+}


### PR DESCRIPTION
## Summary
- allow employees to list projects and project locations
- expose upcoming shift instances and allow shift applications and cancellations
- deliver project announcement feed

## Testing
- `composer test` *(fails: require vendor/autoload.php: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bba31c1bd0833083b0c1c0776ab077